### PR TITLE
Fix analog

### DIFF
--- a/c3d.py
+++ b/c3d.py
@@ -901,8 +901,6 @@ class Reader(Manager):
         skip = self.point_used * 4 * 4
         # set the file handle at the appropriate position.
         self._handle.seek((self.header.data_block - 1) * 512 + skip)
-        # the amount of analog values in a frame for a single channel
-        single_channel_analog = int(self.header.analog_per_frame / self.header.analog_per_frame)
         # obtain all analog values
         all_analog = self.fromfileskip(shape = (self.header.analog_count,), counts = n_frames, skip = skip, dtype = np.float32 )
         # reshape for appropriate dimensions

--- a/c3d.py
+++ b/c3d.py
@@ -800,6 +800,7 @@ class Reader(Manager):
 
         self.check_metadata()
 
+    # taken and adopted from https://stackoverflow.com/questions/14935610/efficient-translation-to-python-of-matlab-fread
     def fromfileskip(self, shape, counts, skip, dtype):
         """
         fid    : file object,    Should be open binary file.

--- a/c3d.py
+++ b/c3d.py
@@ -800,9 +800,9 @@ class Reader(Manager):
 
         self.check_metadata()
 
-    # taken and adopted from https://stackoverflow.com/questions/14935610/efficient-translation-to-python-of-matlab-fread
-    def fromfileskip(self, shape, counts, skip, dtype=np.float32):
+    def fromfileskip(self, shape, counts, skip, dtype):
         """
+        fid    : file object,    Should be open binary file.
         shape  : tuple of ints,  This is the desired shape of each data block.
                For a 2d array with xdim,ydim = 3000,2000 and xdim = fastest 
                dimension, then shape = (2000,3000).
@@ -810,12 +810,11 @@ class Reader(Manager):
         skip   : int, Number of bytes to skip between reads.
         dtype  : np.dtype object, Type of each binary element.
         """
-        fid = self._handle
         data = np.zeros((counts,)  + shape)
         for c in np.arange(counts):
-            block = np.fromfile(fid, dtype=dtype, count=np.product(shape))
+            block = np.fromfile(self._handle, dtype=dtype, count=np.product(shape))
             data[c] = block.reshape(shape)
-            fid.seek( fid.tell() + skip)
+            self._handle.seek( self._handle.tell() + skip)
         return data
 
     def read_frames(self, copy=True):
@@ -885,23 +884,28 @@ class Reader(Manager):
             gen_scale = param.float_value
 
         n_frames = self.last_frame() - self.first_frame() + 1
+        n_words = 4 # x y z and one addtional word for errors
 
         # at the end of every block an amount of analog values multiplied with the byte size value of a float (4) is used to skip
-        skip = self.header.analog_count * 4 
+        skip = self.header.analog_count * n_words
         # set the file handle at the appropriate position.
         self._handle.seek((self.header.data_block - 1) * 512)
         # obtain all point values
-        all_points = self.fromfileskip(shape = (self.point_used, 4), counts = n_frames, skip = skip)
+        all_points = self.fromfileskip(shape = (self.point_used, 4), counts = n_frames, skip = skip, dtype = np.float32 )
         
-        if self.header.analog_count > 0:        
-            # at the end of every block an amount of point values and it's x, y, z values and the 4th word multiplied with a float is used to skip
-            skip = self.point_used * 4 * 4
-            # set the file handle at the appropriate position.
-            self._handle.seek((self.header.data_block - 1) * 512 + skip)
-            # obtain all analog values
-            all_analog = self.fromfileskip(shape = (self.header.analog_count,), counts = n_frames, skip = skip)
-            # reshape for appropriate dimensions
-            all_analog = all_analog.reshape(n_frames, self.header.analog_per_frame, int(self.header.analog_count / self.header.analog_per_frame)).transpose(0,2,1)
+        # at the end of every block an amount of point values and it's x, y, z values and the 4th word multiplied with a float is used to skip
+        skip = self.point_used * 4 * 4
+        # set the file handle at the appropriate position.
+        self._handle.seek((self.header.data_block - 1) * 512 + skip)
+        # the amount of analog values in a frame for a single channel
+
+        apf = self.header.analog_per_frame
+        nc = int(self.header.analog_count / apf)
+        # obtain all analog values
+        all_analog = self.fromfileskip(shape = (self.header.analog_count,), counts = n_frames, skip = skip, dtype = np.float32 )
+        
+        # reshape for appropriate dimensions
+        all_analog = all_analog.T.reshape(apf, n_frames, nc).transpose(1,2,0)
         
         frames = np.arange(n_frames)
         for idx, (f_points, f_analog) in enumerate(zip(all_points, all_analog)):

--- a/c3d.py
+++ b/c3d.py
@@ -891,7 +891,7 @@ class Reader(Manager):
         # set the file handle at the appropriate position.
         self._handle.seek((self.header.data_block - 1) * 512)
         # obtain all point values
-        all_points = self.fromfileskip(shape = (self.point_used, 4), counts = n_frames, skip = skip, dtype = point_dtype)
+        all_points = self.fromfileskip(shape = (self.point_used, n_words), counts = n_frames, skip = skip, dtype = point_dtype)
         
         # at the end of every block an amount of point values and it's x, y, z values and the 4th word multiplied with a float is used to skip
         skip = self.point_used * n_words * point_bytes

--- a/c3d.py
+++ b/c3d.py
@@ -891,18 +891,18 @@ class Reader(Manager):
         # set the file handle at the appropriate position.
         self._handle.seek((self.header.data_block - 1) * 512)
         # obtain all point values
-        all_points = self.fromfileskip(shape = (self.point_used, 4), counts = n_frames, skip = skip, dtype = np.float32 )
+        all_points = self.fromfileskip(shape = (self.point_used, 4), counts = n_frames, skip = skip, dtype = point_dtype)
         
         # at the end of every block an amount of point values and it's x, y, z values and the 4th word multiplied with a float is used to skip
-        skip = self.point_used * 4 * 4
+        skip = self.point_used * n_words * point_bytes
         # set the file handle at the appropriate position.
         self._handle.seek((self.header.data_block - 1) * 512 + skip)
         # the amount of analog values in a frame for a single channel
 
-        apf = self.header.analog_per_frame
-        nc = int(self.header.analog_count / apf)
+        apf = self.header.analog_per_frame # analog per frame
+        nc = int(self.header.analog_count / apf) # number of channels
         # obtain all analog values
-        all_analog = self.fromfileskip(shape = (self.header.analog_count,), counts = n_frames, skip = skip, dtype = np.float32 )
+        all_analog = self.fromfileskip(shape = (self.header.analog_count,), counts = n_frames, skip = skip, dtype = analog_dtype)
         
         # reshape for appropriate dimensions
         all_analog = all_analog.T.reshape(apf, n_frames, nc).transpose(1,2,0)


### PR DESCRIPTION
In my case there was still some weird transposition going on in the analog channels. It took me a while to find out how to solve this, but the PR below is able to produce appropriate output whereas the previous method resulted in strange looking channels.
Also the way of extracting bytes is done at once instead of doing this in a loop, which might result in a speed-up, at the cost of using more memory. In addition some clarity is added for how bytes are extracted.
Probably related to  #7 
This might need some testing for other c3d files.
