### PR TITLE
Update numpy dependency version in pyproject.toml

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.9, ¨3.10¨, 3.11, 3.12]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9, ¨3.10¨, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v2
@@ -29,3 +29,4 @@ jobs:
     - name: Testing
       run: |
         poetry run python -m unittest discover .
+

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -12,12 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, ¨3.10¨, 3.11, 3.12]
-
+         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/c3d/c3d.py
+++ b/c3d/c3d.py
@@ -1529,7 +1529,7 @@ class Manager(object):
             # Manual refer to parsing the parameter as 2 16-bit words, generally equivalent to an uint32
             # end_frame = param.uint32_value
             words = param.uint16_array
-            end_frame = words[0] + words[1] * 65536
+            end_frame = int(words[0]) + int(words[1]) * 65536
             if hlf <= end_frame:
                 return end_frame
         param = self.get('POINT:LONG_FRAMES')

--- a/c3d/c3d.py
+++ b/c3d/c3d.py
@@ -2209,7 +2209,7 @@ class Writer(Manager):
         sh = np.array(frames, dtype=object).shape
         # Single frame
         if len(sh) != 2:
-            frames = [frames]
+            frames = np.array([frames], dtype=object)
             sh = np.shape(frames)
         # Sequence of invalid shape
         if sh[1] != 2:
@@ -2424,7 +2424,7 @@ class Writer(Manager):
 
         # Padding
         self._pad_block(handle)
-        while handle.tell() != 512 * (self.header.data_block - 1):
+        while handle.tell() != 512 * (int(self.header.data_block) - 1):
             handle.write(b'\x00' * 512)
 
     def _write_frames(self, handle):
@@ -2436,7 +2436,7 @@ class Writer(Manager):
             Write metadata and C3D motion frames to the given file handle. The
             writer does not close the handle.
         '''
-        assert handle.tell() == 512 * (self._header.data_block - 1)
+        assert handle.tell() == 512 * (int(self._header.data_block) - 1)
         scale_mag = abs(self.point_scale)
         is_float = self.point_scale < 0
         if is_float:

--- a/c3d/c3d.py
+++ b/c3d/c3d.py
@@ -1513,7 +1513,7 @@ class Manager(object):
             # ACTUAL_START_FIELD is encoded in two 16 byte words...
             # return param.uint32_value
             words = param.uint16_array
-            return words[0] + words[1] * 65535
+            return int(words[0]) + int(words[1]) * 65535
         return self.header.first_frame
 
     @property

--- a/c3d/c3d.py
+++ b/c3d/c3d.py
@@ -2445,7 +2445,7 @@ class Writer(Manager):
 
         # Padding
         self._pad_block(handle)
-        while handle.tell() != 512 * (self.header.data_block - 1):
+        while handle.tell() != 512 * (int(self.header.data_block) - 1):
             handle.write(b'\x00' * 512)
 
     def _write_frames(self, handle):
@@ -2457,7 +2457,7 @@ class Writer(Manager):
             Write metadata and C3D motion frames to the given file handle. The
             writer does not close the handle.
         '''
-        assert handle.tell() == 512 * (self._header.data_block - 1)
+        assert handle.tell() == 512 * (int(self._header.data_block) - 1)
         scale_mag = abs(self.point_scale)
         is_float = self.point_scale < 0
         if is_float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ c3d-metatdata = 'c3d.scripts.c3d_metatdata:main'
 c3d-viewer = 'c3d.scripts.c3d_viewer:main'
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 numpy = ">=1.0.0"
 pyglet = {version = "^1.5.21", optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ c3d-viewer = 'c3d.scripts.c3d_viewer:main'
 
 [tool.poetry.dependencies]
 python = "^3.7"
-numpy = "^1"
+numpy = ">=1.0.0"
 pyglet = {version = "^1.5.21", optional = true}
 
 [tool.poetry.dev-dependencies]

--- a/test/test_frame_count_encodings.py
+++ b/test/test_frame_count_encodings.py
@@ -52,7 +52,7 @@ class Sample19(FrameCountEncodingTest, AnalogSampleCountEncodingTest, verify.Rea
 
     frame_count = [34672]
     sample_count = [624096]
-    zip_files = ['sample19/sample19.c3d']
+    zip_files = ['sample19.c3d']
 
 
 class Sample31(FrameCountEncodingTest, AnalogSampleCountEncodingTest, verify.ReadTest, Base):

--- a/test/test_proc_format.py
+++ b/test/test_proc_format.py
@@ -115,8 +115,8 @@ class Sample02(FormatTest, Base):
     ZIP = 'sample02.zip'
     INTEL_INT = 'pc_int.c3d'
     INTEL_REAL = 'pc_real.c3d'
-    DEC_INT = 'DEC_INT.C3D'
-    DEC_REAL = 'Dec_real.c3d'
+    DEC_INT = 'dec_int.c3d'
+    DEC_REAL = 'dec_real.c3d'
     MIPS_INT = 'sgi_int.c3d'
     MIPS_REAL = 'sgi_real.c3d'
 

--- a/test/verify.py
+++ b/test/verify.py
@@ -68,7 +68,7 @@ class ReadTest():
         # Allow self.zipfiles on form:
         # ['FILE', ..]
         # [('FOLDER', ['FILE', ..])]
-        if len(np.shape(self.zip_files)) == 1:
+        if len(np.array(self.zip_files, dtype=object).shape) == 1:
             for file in self.zip_files:
                 check_zipfile(file)
         else:
@@ -130,7 +130,7 @@ class WithinRangeTest():
         print('----------------------------')
         print(type(self))
         print('----------------------------')
-        if len(np.shape(self.zip_files)) == 1:
+        if len(np.array(self.zip_files, dtype=object).shape) == 1:
             for file in self.zip_files:
                 check_zipfile(file)
         else:

--- a/test/verify.py
+++ b/test/verify.py
@@ -65,10 +65,18 @@ class ReadTest():
 
             print('{} | READ: OK'.format(file))
 
-        # Allow self.zipfiles on form:
-        # ['FILE', ..]
-        # [('FOLDER', ['FILE', ..])]
-        if len(np.shape(self.zip_files)) == 1:
+        # Check if zip_files is a simple list of files or nested folder structure
+        # Simple list: ['file1', 'file2', ...]  
+        # Nested: [('folder', ['file1', 'file2']), ...]
+        is_simple_list = True
+        if self.zip_files and len(self.zip_files) > 0:
+            first_item = self.zip_files[0]
+            if isinstance(first_item, (tuple, list)) and len(first_item) == 2:
+                folder_name, files = first_item
+                if isinstance(files, (list, tuple)):
+                    is_simple_list = False
+
+        if is_simple_list:
             for file in self.zip_files:
                 check_zipfile(file)
         else:
@@ -130,7 +138,18 @@ class WithinRangeTest():
         print('----------------------------')
         print(type(self))
         print('----------------------------')
-        if len(np.shape(self.zip_files)) == 1:
+        # Check if zip_files is a simple list of files or nested folder structure
+        # Simple list: ['file1', 'file2', ...]  
+        # Nested: [('folder', ['file1', 'file2']), ...]
+        is_simple_list = True
+        if self.zip_files and len(self.zip_files) > 0:
+            first_item = self.zip_files[0]
+            if isinstance(first_item, (tuple, list)) and len(first_item) == 2:
+                folder_name, files = first_item
+                if isinstance(files, (list, tuple)):
+                    is_simple_list = False
+
+        if is_simple_list:
             for file in self.zip_files:
                 check_zipfile(file)
         else:

--- a/test/zipload.py
+++ b/test/zipload.py
@@ -8,12 +8,12 @@ import zipfile
 TEMP = os.path.join(tempfile.gettempdir(), 'c3d-test')
 ZIPS = (
     ('https://www.c3d.org/data/Sample00.zip', 'sample00.zip'),
-    ('https://www.c3d.org/data/sample01.zip', 'sample01.zip'),
-    ('https://www.c3d.org/data/sample02.zip', 'sample02.zip'),
-    ('https://www.c3d.org/data/sample07.zip', 'sample07.zip'),
-    ('https://www.c3d.org/data/sample08.zip', 'sample08.zip'),
-    ('https://www.c3d.org/data/sample19.zip', 'sample19.zip'),
-    ('https://www.c3d.org/data/sample31.zip', 'sample31.zip'),
+    ('https://www.c3d.org/data/Sample01.zip', 'sample01.zip'),
+    ('https://www.c3d.org/data/Sample02.zip', 'sample02.zip'),
+    ('https://www.c3d.org/data/Sample07.zip', 'sample07.zip'),
+    ('https://www.c3d.org/data/Sample08.zip', 'sample08.zip'),
+    ('https://www.c3d.org/data/Sample19.zip', 'sample19.zip'),
+    ('https://www.c3d.org/data/Sample31.zip', 'sample31.zip'),
     ('https://www.c3d.org/data/Sample36.zip', 'sample36.zip'),
 )
 


### PR DESCRIPTION
From the tests I ran (not extensive though), py-c3d works fine with numpy >= 2.0. Allowing it would help with dependency conflicts due to many newer libraries requiring later numpy versions.